### PR TITLE
Wrong config order

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -7,10 +7,10 @@ require(__DIR__ . '/../vendor/autoload.php');
 require(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
 
 $config = yii\helpers\ArrayHelper::merge(
-    require(__DIR__ . '/../config/main.php'),
-    require(__DIR__ . '/../config/main.local.php'),
     require(__DIR__ . '/../config/common.php'),
-    require(__DIR__ . '/../config/common.local.php')
+    require(__DIR__ . '/../config/common.local.php'),
+    require(__DIR__ . '/../config/main.php'),
+    require(__DIR__ . '/../config/main.local.php')
 );
 
 (new yii\web\Application($config))->run();

--- a/yii
+++ b/yii
@@ -18,10 +18,10 @@ require(__DIR__ . '/vendor/autoload.php');
 require(__DIR__ . '/vendor/yiisoft/yii2/Yii.php');
 
 $config = yii\helpers\ArrayHelper::merge(
-    require(__DIR__ . '/config/console.php'),
-    require(__DIR__ . '/config/console.local.php'),
     require(__DIR__ . '/config/common.php'),
-    require(__DIR__ . '/config/common.local.php')
+    require(__DIR__ . '/config/common.local.php'),
+    require(__DIR__ . '/config/console.php'),
+    require(__DIR__ . '/config/console.local.php')
 );
 
 $application = new yii\console\Application($config);


### PR DESCRIPTION
As I understand "common" configs must be loaded before "main" and "console".